### PR TITLE
fix: use poolOptions.threads.singleThread instead of invalid threads option

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,11 @@ export default defineConfig({
     teardownTimeout: 10000,
     retry: 2,
     maxConcurrency: 4,
-    threads: false,
+    poolOptions: {
+      threads: {
+        singleThread: true
+      }
+    },
     alias: {
       'simulation-wasm/simulation_wasm_bg.wasm': path.resolve(__dirname, 'src/__mocks__/wasmMock.js'),
       '@/utils': path.resolve(__dirname, './src/components/utils'),


### PR DESCRIPTION
Fixes TypeScript compilation error in vitest.config.ts

```
vitest.config.ts(17,5): error TS2769: 'threads' does not exist in type 'InlineConfig'
```

Uses `poolOptions: { threads: { singleThread: true } }` instead.